### PR TITLE
Change font imports to absolute paths

### DIFF
--- a/src/sass/standard/base/_typography.sass
+++ b/src/sass/standard/base/_typography.sass
@@ -1,16 +1,16 @@
 @font-face
   font-family: Calibre
-  src: url('vendor/fonts/CalibreWeb-Light.ttf')
+  src: url('/vendor/fonts/CalibreWeb-Light.ttf')
   font-weight: 300
 
 @font-face
   font-family: Calibre
-  src: url('vendor/fonts/CalibreWeb-Regular.ttf')
+  src: url('/vendor/fonts/CalibreWeb-Regular.ttf')
   font-weight: 400
 
 @font-face
   font-family: Calibre
-  src: url('vendor/fonts/CalibreWeb-Semibold.ttf')
+  src: url('/vendor/fonts/CalibreWeb-Semibold.ttf')
   font-weight: 600
 
 $alignment: center left right


### PR DESCRIPTION
In order to build with webpack, we need to use absolute imports here, since webpack resolves URLs relative to the root file rather than relative to the SCSS file